### PR TITLE
Makefile updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+linters:
+  enable:
+  - exhaustive
+  - goconst
+  - goerr113
+  - gofmt
+  - gofumpt
+  - goimports
+  - golint
+  - goprintffuncname
+  - gosec
+  - interfacer
+  - misspell
+  - whitespace
+linters-settings:
+  goimports:
+    local-prefixes: github.com/hydralang/ptk

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: go
 go:
 - "1.13.x"
 - "1.14.x"
+- "1.15.x"
 script:
 - make all goveralls CI=true


### PR DESCRIPTION
This merge request makes some updates to the Makefile.  It removes the unnecessary copyright header, formally putting the Makefile into the public domain; it switches linting to use golangci-lint to speed up linting runs; it makes a couple of minor ordering changes to the Makefile; and it adds go 1.15.x to the build matrix.