### PR TITLE
Add an imports target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ TOOLS         =
 
 # Names of the various commands
 GO            = go
+GOIMPORTS     = ./$(TOOLDIR)/goimports
+TOOLS         += golang.org/x/tools/cmd/goimports
 GOLANGCI_LINT = ./$(TOOLDIR)/golangci-lint
 OVERCOVER     = ./$(TOOLDIR)/overcover
 TOOLS         += github.com/klmitch/overcover
@@ -91,6 +93,9 @@ build: $(BINS) ## Build binaries (if any)
 
 tidy: ## Ensure go.mod matches the source code
 	$(GO) mod tidy
+
+imports: $(GOIMPORTS) ## Maintain the source imports
+	$(GOIMPORTS) -l -local $(PKG_ROOT) -w $(SOURCES)
 
 lint: $(GOLANGCI_LINT) $(LINT_CONF) ## Lint-check source files; may fix some lint issues
 	$(GOLANGCI_LINT) run -c $(LINT_CONF) $(LINT_ARG) $(PACKAGES)
@@ -211,4 +216,4 @@ help: ## Emit help for the Makefile
 			} \
 		}'
 
-.PHONY: all build tidy lint test-only test cover cover-report cover-test goveralls clean help
+.PHONY: all build tidy imports lint test-only test cover cover-report cover-test goveralls clean help


### PR DESCRIPTION
One of the nice things about `goimports` which `golangci-lint` cannot do is that `goimports` is able to manage the imports for a package, adding newly needed imports to a source file.  It's even able to make a reasonable guess as to which import may be needed for a referenced package and add that package import to `go.mod`.  Since this cannot be done by `golangci-lint`, this pull request adds back an `imports` target to the `Makefile` that simply runs `goimports` on the source files.  This can be used during development, prior to running a `make test`, to manage the imports.