### PR TITLE
Allow for custom BackTracker

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -37,8 +37,15 @@ type Lexer struct {
 
 // New constructs a new Lexer using the provided source and state.
 func New(src scanner.Scanner, state State) *Lexer {
+	// Wrap the scanner to allow for backtracking
+	var ok bool
+	var bt IBackTracker
+	if bt, ok = src.(IBackTracker); !ok {
+		bt = NewBackTracker(src, TrackAll)
+	}
+
 	return &Lexer{
-		Scanner: NewBackTracker(src, TrackAll),
+		Scanner: bt,
 		State:   state,
 		toks:    &list.List{},
 	}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -27,7 +27,7 @@ func TestLexerImplementsILexer(t *testing.T) {
 	assert.Implements(t, (*ILexer)(nil), &Lexer{})
 }
 
-func TestNew(t *testing.T) {
+func TestNewBase(t *testing.T) {
 	src := &mockScanner{}
 	state := &mockState{}
 
@@ -35,6 +35,18 @@ func TestNew(t *testing.T) {
 
 	require.NotNil(t, result.Scanner)
 	assert.Same(t, src, result.Scanner.(*BackTracker).Src)
+	assert.Same(t, state, result.State)
+	assert.Equal(t, &list.List{}, result.toks)
+}
+
+func TestNewWithBackTracker(t *testing.T) {
+	src := &mockBackTracker{}
+	state := &mockState{}
+
+	result := New(src, state)
+
+	require.NotNil(t, result.Scanner)
+	assert.Same(t, src, result.Scanner)
 	assert.Same(t, state, result.State)
 	assert.Equal(t, &list.List{}, result.toks)
 }


### PR DESCRIPTION
The `parser.New` function implements selective wrapping of the lexer, only wrapping it in a `PushBackLexer` if it doesn't implement the `IPushBackLexer` interface.  This allows callers to substitute their own `IPushBackLexer` implementation.  This commit extends this logic into `lexer.New`, allowing alternate implementations of `IBackTracker` to be passed when constructing the `Lexer`.